### PR TITLE
handling of null objects for flow files returned from the session 'get'-method

### DIFF
--- a/src/main/java/com/github/whiver/nifi/processor/ProtobufDecoder.java
+++ b/src/main/java/com/github/whiver/nifi/processor/ProtobufDecoder.java
@@ -58,6 +58,11 @@ public class ProtobufDecoder extends ProtobufProcessor {
 
         final FlowFile flowfile = session.get();
 
+        //it could be that another thread already got the flowfile -> Leave the function
+        if(flowfile == null) {
+        	return;
+        }
+
         String protobufSchema = flowfile.getAttribute(PROTOBUF_SCHEMA.getName());
         boolean compileSchema = processContext.getProperty(COMPILE_SCHEMA.getName()).asBoolean();
         String messageType = flowfile.getAttribute("protobuf.messageType");

--- a/src/main/java/com/github/whiver/nifi/processor/ProtobufEncoder.java
+++ b/src/main/java/com/github/whiver/nifi/processor/ProtobufEncoder.java
@@ -54,6 +54,10 @@ public class ProtobufEncoder extends ProtobufProcessor {
         final AtomicReference<Relationship> error = new AtomicReference<>();
 
         final FlowFile flowfile = session.get();
+      //it could be that another thread already got the flowfile -> Leave the function
+        if(flowfile == null) {
+        	return;
+        }
 
         // We check if the protobuf.schemaPath property is defined in the flowfile
         String protobufSchema = flowfile.getAttribute(PROTOBUF_SCHEMA.getName());


### PR DESCRIPTION
Hi,

we are using the decoding processor with concurrent tasks. We found that it could happen that several threads try to access the same flowfile concurrently. In this scenario, all threads except one retrieve from the session.get() call a null object instead of a flowfile object. This pull requests handles this case...

Best,
Thomas